### PR TITLE
Add Running status

### DIFF
--- a/src/AcmInlineStatus/AcmInlineStatus.tsx
+++ b/src/AcmInlineStatus/AcmInlineStatus.tsx
@@ -10,6 +10,7 @@ import {
     MinusCircleIcon,
     UnknownIcon,
     ResourcesEmptyIcon,
+    RunningIcon,
     FileAltIcon,
 } from '@patternfly/react-icons'
 import React from 'react'
@@ -42,6 +43,7 @@ export enum StatusType {
     'sleep' = 'sleep',
     'empty' = 'empty',
     'draft' = 'draft',
+    'running' = 'running',
 }
 
 export function AcmInlineStatus(props: { type: StatusType; status: string | React.ReactNode; popover?: PopoverProps }) {
@@ -89,6 +91,8 @@ function StatusIcon(props: { type: StatusType }) {
             return <ResourcesEmptyIcon className={classes.iconMargin} color="var(--pf-global--disabled-color--100)" />
         case StatusType.draft:
             return <FileAltIcon className={classes.iconMargin} color="var(--pf-global--disabled-color--100)" />
+        case StatusType.running:
+            return <RunningIcon className={classes.iconMargin} color="var(--pf-global--success-color--100)" />
         case 'unknown':
         default:
             return <UnknownIcon className={classes.iconMargin} color="var(--pf-global--disabled-color--100)" />

--- a/src/AcmTable/AcmTable.stories.tsx
+++ b/src/AcmTable/AcmTable.stories.tsx
@@ -464,7 +464,7 @@ function getProviderForItem(item: IExampleData) {
 
 function getAcmInlineStatusForItem(item: IExampleData) {
     const chr = item.last_name.charCodeAt(0)
-    switch (chr % 5) {
+    switch (chr % 6) {
         case 0:
             return <AcmInlineStatus type={StatusType.healthy} status="Healthy" />
         case 1:
@@ -473,6 +473,8 @@ function getAcmInlineStatusForItem(item: IExampleData) {
             return <AcmInlineStatus type={StatusType.warning} status="Warning" />
         case 3:
             return <AcmInlineStatus type={StatusType.danger} status="Danger" />
+        case 4:
+            return <AcmInlineStatus type={StatusType.running} status="Running" />
         default:
             return <AcmInlineStatus type={StatusType.progress} status="Progressing" />
     }


### PR DESCRIPTION
Signed-off-by: Kevin Cormier <kcormier@redhat.com>

To be used for status of "hot" clusters in a cluster pool. (`spec.runningCount`)

![image](https://user-images.githubusercontent.com/42188127/157530194-902009ac-968c-422c-b003-9f1ab6ea1ec3.png)
