### PR TITLE
acmtable performance

### DIFF
--- a/src/AcmTable/AcmTable.tsx
+++ b/src/AcmTable/AcmTable.tsx
@@ -658,7 +658,7 @@ export function AcmTable<T>(props: AcmTableProps<T>) {
             }
         })
         return { rows: newRows, addedSubRowCount }
-    }, [selected, paged, columns, expanded, openGroups, keyFn])
+    }, [JSON.stringify(selected), paged, columns, expanded, openGroups, keyFn])
 
     const onCollapse = useMemo<((_event: unknown, rowIndex: number, isOpen: boolean) => void) | undefined>(() => {
         if (groupFn && addedSubRowCount) {


### PR DESCRIPTION
every time the items changed, a new selected object was created:

    useLayoutEffect(() => {
        const newSelected: { [uid: string]: boolean } = {}
         :             :             :
        setSelected(newSelected)
    }, [items])

which caused the memo used to calculate the rows to re-run:

    const { rows, addedSubRowCount } = useMemo<{ rows: IRow[]; addedSubRowCount: number }>(() => {

         :             :             :

    }, selected, paged, columns, expanded, openGroups, keyFn])

because react just uses === to determine if the dependency changes  and it was always a new object:

so fix is to compare the json of the object:

    }, [JSON.stringify(selected), paged, columns, expanded, openGroups, keyFn])


Signed-off-by: John Swanke <jswanke@redhat.com>